### PR TITLE
[docs] add Azure Orkestra to projects using Argo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Other open source projects that use Argo:
 * [Seldon](https://github.com/SeldonIO/seldon-core) is an MLOps framework to package, deploy, monitor and manage thousands of production machine learning models.
 * [SQLFlow](https://github.com/sql-machine-learning/sqlflow) extends SQL to support AI and compiles the SQL program to a workflow that runs on Kubernetes.
 * [terraform-provider-argocd](https://github.com/oboukili/terraform-provider-argocd) is the Terraform provider for Argo CD.
+* [Azure Orkestra](https://github.com/Azure/orkestra) is a cloud-native release orchestration and lifecycle management (LCM) platform for the fine-grained orchestration of inter-dependent helm charts and their dependencies
 
 <a name="books" />
 


### PR DESCRIPTION
Azure Orkestra uses Argo Workflows as a native component and is capable of being directly plugged into ArgoCD. An Argo Rollouts plugin can be integrated into Orkestra to generate and run canary & AB tests.